### PR TITLE
Hostname handling fixes

### DIFF
--- a/spnego.go
+++ b/spnego.go
@@ -32,3 +32,19 @@ func canonicalizeHostname(hostname string) (string, error) {
 
 	return strings.TrimRight(names[0], "."), nil
 }
+
+func getHostname(req *http.Request, canonicalize bool) (string, error) {
+	var err error
+
+	h := req.URL.Host // SPN should contain the port, if non-standard (https://social.technet.microsoft.com/wiki/contents/articles/717.service-principal-names-spn-setspn-syntax.aspx)
+	if req.Host != "" {
+		h = req.Host
+	}
+	if canonicalize {
+		if h, err = canonicalizeHostname(h); err != nil {
+			return "", err
+		}
+	}
+
+	return h, nil
+}

--- a/spnego.go
+++ b/spnego.go
@@ -40,6 +40,11 @@ func getHostname(req *http.Request, canonicalize bool) (string, error) {
 	if req.Host != "" {
 		h = req.Host
 	}
+	// I can't think why you'd want to canonicalize an overridden Host
+	// header (you're likely to get the hostname in the URL, which is what
+	// you're overriding in the first place). But since it can be disabled,
+	// leave it here in the flow so that Host header hostnames can be
+	// canonicalized if desired.
 	if canonicalize {
 		if h, err = canonicalizeHostname(h); err != nil {
 			return "", err

--- a/spnego_gokrb5.go
+++ b/spnego_gokrb5.go
@@ -68,12 +68,9 @@ func (k *krb5) makeClient() error {
 }
 
 func (k *krb5) SetSPNEGOHeader(req *http.Request, canonicalize bool) error {
-	h := req.URL.Host // SPN should contain the port, if non-standard (https://social.technet.microsoft.com/wiki/contents/articles/717.service-principal-names-spn-setspn-syntax.aspx)
-	if canonicalize {
-		var err error
-		if h, err = canonicalizeHostname(h); err != nil {
-			return err
-		}
+	h, err := getHostname(req, canonicalize)
+	if err != nil {
+		return err
 	}
 
 	if err := k.makeCfg(); err != nil {

--- a/spnego_gokrb5.go
+++ b/spnego_gokrb5.go
@@ -68,7 +68,7 @@ func (k *krb5) makeClient() error {
 }
 
 func (k *krb5) SetSPNEGOHeader(req *http.Request, canonicalize bool) error {
-	h := req.URL.Hostname()
+	h := req.URL.Host // SPN should contain the port, if non-standard (https://social.technet.microsoft.com/wiki/contents/articles/717.service-principal-names-spn-setspn-syntax.aspx)
 	if canonicalize {
 		var err error
 		if h, err = canonicalizeHostname(h); err != nil {

--- a/spnego_test.go
+++ b/spnego_test.go
@@ -1,0 +1,129 @@
+package spnego
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+func TestGetHostnameEmptyHost(t *testing.T) {
+	desired := "example.com"
+
+	url, err := url.Parse("http://example.com/path")
+	if err != nil {
+		panic(err)
+	}
+	req := &http.Request{
+		URL: url,
+	}
+	t.Logf("url %s, host %s\n", req.URL.Host, req.Host)
+
+	h, err := getHostname(req, false)
+	if err != nil {
+		panic(err)
+	}
+
+	if h != desired {
+		t.Errorf("Hostname was incorrect: wanted %s, got %s.", desired, h)
+	}
+}
+
+func TestGetHostnameEmptyHostPort(t *testing.T) {
+	desired := "example.com:8080"
+
+	url, err := url.Parse("http://example.com:8080/path")
+	if err != nil {
+		panic(err)
+	}
+	req := &http.Request{
+		URL: url,
+	}
+	t.Logf("url %s, host %s\n", req.URL.Host, req.Host)
+
+	h, err := getHostname(req, false)
+	if err != nil {
+		panic(err)
+	}
+
+	if h != desired {
+		t.Errorf("Hostname was incorrect: wanted %s, got %s.", desired, h)
+	}
+}
+
+func TestGetHostnameHost(t *testing.T) {
+	desired := "example.com"
+
+	req, err := http.NewRequest("GET", "http://example.com/path", nil)
+	if err != nil {
+		panic(err)
+	}
+	t.Logf("url %s, host %s\n", req.URL.Host, req.Host)
+
+	h, err := getHostname(req, false)
+	if err != nil {
+		panic(err)
+	}
+
+	if h != desired {
+		t.Errorf("Hostname was incorrect: wanted %s, got %s.", desired, h)
+	}
+}
+
+func TestGetHostnameHostWithPort(t *testing.T) {
+	desired := "example.com:8080"
+
+	req, err := http.NewRequest("GET", "http://example.com:8080/path", nil)
+	if err != nil {
+		panic(err)
+	}
+	t.Logf("url %s, host %s\n", req.URL.Host, req.Host)
+
+	h, err := getHostname(req, false)
+	if err != nil {
+		panic(err)
+	}
+
+	if h != desired {
+		t.Errorf("Hostname was incorrect: wanted %s, got %s.", desired, h)
+	}
+}
+
+func TestGetHostnameOverride(t *testing.T) {
+	desired := "override.org"
+
+	req, err := http.NewRequest("GET", "http://example.com:8080/path", nil)
+	if err != nil {
+		panic(err)
+	}
+	req.Host = "override.org"
+	t.Logf("url %s, host %s\n", req.URL.Host, req.Host)
+
+	h, err := getHostname(req, false)
+	if err != nil {
+		panic(err)
+	}
+
+	if h != desired {
+		t.Errorf("Hostname was incorrect: wanted %s, got %s.", desired, h)
+	}
+}
+
+func TestGetHostnameOverrideWithPort(t *testing.T) {
+	desired := "override.org:1234"
+
+	req, err := http.NewRequest("GET", "http://example.com:8080/path", nil)
+	if err != nil {
+		panic(err)
+	}
+	req.Host = "override.org:1234"
+	t.Logf("url %s, host %s\n", req.URL.Host, req.Host)
+
+	h, err := getHostname(req, false)
+	if err != nil {
+		panic(err)
+	}
+
+	if h != desired {
+		t.Errorf("Hostname was incorrect: wanted %s, got %s.", desired, h)
+	}
+}

--- a/spnego_windows.go
+++ b/spnego_windows.go
@@ -19,12 +19,9 @@ func New() Provider {
 
 // SetSPNEGOHeader puts the SPNEGO authorization header on HTTP request object
 func (s *sspi) SetSPNEGOHeader(req *http.Request, canonicalize bool) error {
-	h := req.URL.Host // SPN should contain the port, if non-standard (https://social.technet.microsoft.com/wiki/contents/articles/717.service-principal-names-spn-setspn-syntax.aspx)
-	if canonicalize {
-		var err error
-		if h, err = canonicalizeHostname(h); err != nil {
-			return err
-		}
+	h, err := getHostname(req, canonicalize)
+	if err != nil {
+		return err
 	}
 	spn := "HTTP/" + h
 

--- a/spnego_windows.go
+++ b/spnego_windows.go
@@ -19,7 +19,7 @@ func New() Provider {
 
 // SetSPNEGOHeader puts the SPNEGO authorization header on HTTP request object
 func (s *sspi) SetSPNEGOHeader(req *http.Request, canonicalize bool) error {
-	h := req.URL.Hostname()
+	h := req.URL.Host // SPN should contain the port, if non-standard (https://social.technet.microsoft.com/wiki/contents/articles/717.service-principal-names-spn-setspn-syntax.aspx)
 	if canonicalize {
 		var err error
 		if h, err = canonicalizeHostname(h); err != nil {


### PR DESCRIPTION
Firstly, the MS docs say the SPN should contain a port number if the port is non-standard; introduce this behaviour.

Secondly, if the Host header has been overridden, use that for the SPN as that's almost certainly the service's idea of its own name (rather than the host in the URL, which is what will be dialled).